### PR TITLE
ci: apply zizmor security fixes to workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - run: corepack enable
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:


### PR DESCRIPTION
## Changes

- Add `persist-credentials: false` to every `actions/checkout` step.

Applies the auto-fixes from zizmor 1.25.2 using `--fix=all`.

## Background

`--fix=safe` applies nothing here: the `artipacked` (persist-credentials) auto-fix is classified as unsafe, so every fix is held back in safe mode. `--fix=all` is used instead.

## Notes

- SHA pinning is out of scope — it is delegated to Renovate (`config:best-practices`).
- `excessive-permissions` findings have no auto-fix and are handled separately, per job.
- None of the affected workflows run `git push`; they all pass `secrets.GITHUB_TOKEN` explicitly, so `persist-credentials: false` is not expected to break anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
