### PR TITLE
ci: guard the release step and disable caching

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: "pnpm"
+          package-manager-cache: false
       - name: Export current version
         run: echo "SNACK_CARDS_VERSION=v$(jq -r .version package.json)" >> $GITHUB_ENV
       - run: pnpm install --frozen-lockfile
@@ -41,6 +41,7 @@ jobs:
           ZIP_FILE=$(find .output -name "*.zip" -type f | head -n 1)
           echo "zip_file=$ZIP_FILE" >> $GITHUB_OUTPUT
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           name: Release ${{ env.SNACK_CARDS_VERSION }}


### PR DESCRIPTION
## Changes

- Guard the `Create Release` step with `if: startsWith(github.ref, 'refs/tags/')`.
- Disable `actions/setup-node` package manager caching in this workflow (`package-manager-cache: false`), and drop the explicit `cache: "pnpm"`.

## Why

This workflow has `workflow_dispatch` but nothing ties the release to a tag. `softprops/action-gh-release` is used without a `tag_name`, so it derives the tag from `github.ref` and [throws when the ref is not a tag](https://github.com/softprops/action-gh-release/blob/3d0d9888cb7fd7b750713d6e236d1fcb99157228/src/run.ts), which means a branch dispatch fails rather than publishing something wrong. That backstop only holds while `draft` stays false, though, so the explicit `if:` makes the intent independent of the action's internals — and it turns a red run into a clean skip.

Caching is disabled because a release workflow restoring a cache written by another run is the [cache-poisoning](https://docs.zizmor.sh/audits/#cache-poisoning) risk zizmor flags. `package-manager-cache` [defaults to true](https://github.com/actions/setup-node/blob/820762786026740c76f36085b0efc47a31fe5020/action.yml) in setup-node v7, so it has to be turned off explicitly.

## Verification

`actionlint` reports no new findings and the zizmor High-severity finding for this file is resolved. Note that this workflow is **not** exercised by pull request CI — it only triggers on tag pushes and manual dispatch — so these changes are verified statically, not by a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
