### PR TITLE
ci: add timeouts to workflow jobs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Changes

- Add `timeout-minutes: 10` to every job in this repository's workflows.

## Why

An E2E job in another repository hung for 60 minutes today when `apt-get update` could not reach its mirror. Because that job had no `timeout-minutes`, the [default of 360 minutes](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes) applied, so a stuck job would have burned six hours of runner time before being killed.

The value is derived from this workflow's own history: the last 30 successful runs are all well under two minutes, so 10 minutes leaves a wide margin while still catching a hang quickly.

Verified with `actionlint` and `zizmor --offline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
