### PR TITLE
ci: use gh release instead of a third-party action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,9 +43,12 @@ jobs:
           echo "zip_file=$ZIP_FILE" >> $GITHUB_OUTPUT
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          name: Release ${{ env.SNACK_CARDS_VERSION }}
-          files: ${{ steps.find_zip.outputs.zip_file }}
-          draft: false
-          prerelease: false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIP_FILE: ${{ steps.find_zip.outputs.zip_file }}
+        run: >-
+          gh release create "${GITHUB_REF_NAME}"
+          "${ZIP_FILE}"
+          --verify-tag
+          --title "Release ${SNACK_CARDS_VERSION}"
+          --notes ""


### PR DESCRIPTION
## Changes

- Replace `softprops/action-gh-release` with `gh release create` in the `Create Release` step.

## Why

zizmor's [`superfluous-actions`](https://docs.zizmor.sh/audits/#superfluous-actions) audit flags this: `gh` is preinstalled on GitHub-hosted runners, so a third-party action is not needed to cut a release. Dropping it removes one dependency from the release path, which is exactly where supply-chain surface matters most.

## Safety

`softprops/action-gh-release` had a useful property this replaces: with no `tag_name` and a non-tag ref it [throws before touching the API](https://github.com/softprops/action-gh-release/blob/3d0d9888cb7fd7b750713d6e236d1fcb99157228/src/run.ts), which meant a mistaken dispatch failed instead of publishing something.

`gh release create` has the opposite default — if the tag does not exist it [creates one from the latest state of the default branch](https://cli.github.com/manual/gh_release_create) and publishes a real release. So `--verify-tag` is not optional here; it aborts when the tag is not already on the remote, restoring the same protection. The existing `if: startsWith(github.ref, 'refs/tags/')` guard stays as the first layer.

## Behavior

`GITHUB_REF_NAME` is the tag name, matching what the action derived from `github.ref`. `--notes ""` reproduces the empty body the action produced (`generate_release_notes` defaulted to false). `draft` and `prerelease` default to false in `gh`, same as before.

## Verification

`actionlint` and `zizmor --offline` both clean. Note this workflow only runs on tag pushes, so it is **not** covered by pull request CI — the first real exercise will be the next release.

The release title keeps using `SNACK_CARDS_VERSION` (`--title "Release ${SNACK_CARDS_VERSION}"`), and the zip path moves from a `files:` input to a `ZIP_FILE` env var so it is never interpolated into the shell command.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
