### PR TITLE
fix: make the release step idempotent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,16 +39,19 @@ jobs:
       - name: Find zip file
         id: find_zip
         run: |
-          ZIP_FILE=$(find .output -name "*.zip" -type f | head -n 1)
+          ZIP_FILE=$(find .output -name "*.zip" -type f -print -quit)
           echo "zip_file=$ZIP_FILE" >> $GITHUB_OUTPUT
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ZIP_FILE: ${{ steps.find_zip.outputs.zip_file }}
-        run: >-
-          gh release create "${GITHUB_REF_NAME}"
-          "${ZIP_FILE}"
-          --verify-tag
-          --title "Release ${SNACK_CARDS_VERSION}"
-          --notes ""
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" "${ZIP_FILE}" --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" "${ZIP_FILE}" \
+              --verify-tag \
+              --title "Release ${SNACK_CARDS_VERSION}" \
+              --notes ""
+          fi


### PR DESCRIPTION
## Changes

- Make the release step idempotent (see below).
- Replace `find … | head -n 1` with `find … -print -quit`.

## Why

`softprops/action-gh-release`, which this workflow used until earlier today, updates an existing release rather than failing: *"If a tag already has a GitHub release, the existing release will be updated with the release assets"* ([README](https://github.com/softprops/action-gh-release/blob/3d0d9888cb7fd7b750713d6e236d1fcb99157228/README.md)). `gh release create` fails instead — observed for real in [this run](https://github.com/corrupt952/SnackTime/actions/runs/32208348696): `a release with the same tag name already exists`.

Replacing the action therefore removed the ability to re-run a release after a partial failure. If an asset upload dies on a network error, the old setup recovered on re-run; the new one failed until the release was deleted by hand. All three release workflows have `workflow_dispatch`, so re-running is a real path, not a hypothetical.

Checking for an existing release and falling back to `gh release upload --clobber` restores that. The `--verify-tag` guard stays on the create path.

This is a regression I introduced today and did not flag in the PR that made the switch.

## The `find` change

This workflow sets `defaults.run.shell: bash`, which runs `bash --noprofile --norc -eo pipefail` rather than the default `bash -e` ([workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsstepshell)). Under `pipefail`, `head -n 1` exiting first makes `find` take SIGPIPE, the pipeline returns 141, and `set -e` kills the step with no error message.

Reproduced locally: with one match it exits 0, with many matches it exits 141. Today it passes only because `wxt zip` emits a single zip. Adding `zip:firefox` to CI, or WXT starting to emit a sources zip, would break it. `-print -quit` removes the pipe entirely.

This one predates today — both the `defaults` block and the `find` pipeline were already in place on 2026-08-03.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
