### PR TITLE
fix: make tsc --noEmit pass and restore compile in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
+      - run: pnpm compile
       - run: pnpm test
       - run: pnpm build
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -4,14 +4,14 @@ export default defineBackground(() => {
   // Update badge with total reading list count
   const updateBadge = async () => {
     try {
-      const items = await chrome.readingList.query({});
+      const items = await browser.readingList.query({});
       const totalCount = items.length;
 
       if (totalCount > 0) {
-        await chrome.action.setBadgeText({ text: String(totalCount) });
-        await chrome.action.setBadgeBackgroundColor({ color: "#57534e" });
+        await browser.action.setBadgeText({ text: String(totalCount) });
+        await browser.action.setBadgeBackgroundColor({ color: "#57534e" });
       } else {
-        await chrome.action.setBadgeText({ text: "" });
+        await browser.action.setBadgeText({ text: "" });
       }
     } catch (error) {
       console.error("Failed to update badge:", error);
@@ -22,15 +22,15 @@ export default defineBackground(() => {
   updateBadge();
 
   // Update badge when reading list changes
-  chrome.readingList.onEntryAdded.addListener(() => {
+  browser.readingList.onEntryAdded.addListener(() => {
     updateBadge();
   });
 
-  chrome.readingList.onEntryRemoved.addListener(() => {
+  browser.readingList.onEntryRemoved.addListener(() => {
     updateBadge();
   });
 
-  chrome.readingList.onEntryUpdated.addListener(() => {
+  browser.readingList.onEntryUpdated.addListener(() => {
     updateBadge();
   });
 

--- a/entrypoints/sidepanel/App.tsx
+++ b/entrypoints/sidepanel/App.tsx
@@ -24,7 +24,7 @@ export default function App() {
     try {
       setLoading(true);
       setError(null);
-      const readingListItems = await chrome.readingList.query({});
+      const readingListItems = await browser.readingList.query({});
       const sortedItems = readingListItems.sort((a, b) => (b.creationTime || 0) - (a.creationTime || 0));
       setItems(sortedItems);
     } catch (err) {
@@ -37,7 +37,7 @@ export default function App() {
 
   const markAsOpened = async (url: string) => {
     try {
-      await chrome.readingList.updateEntry({ url, hasBeenRead: true });
+      await browser.readingList.updateEntry({ url, hasBeenRead: true });
       setItems((prev) => prev.map((item) => (item.url === url ? { ...item, hasBeenRead: true } : item)));
     } catch (error) {
       console.error("Failed to mark as opened:", error);
@@ -46,7 +46,7 @@ export default function App() {
 
   const removeItem = async (url: string) => {
     try {
-      await chrome.readingList.removeEntry({ url });
+      await browser.readingList.removeEntry({ url });
       setItems((prev) => prev.filter((item) => item.url !== url));
     } catch (error) {
       console.error("Failed to remove item:", error);
@@ -54,9 +54,9 @@ export default function App() {
   };
 
   const openInCurrentTab = async (url: string) => {
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
     if (tab?.id) {
-      chrome.tabs.update(tab.id, { url });
+      browser.tabs.update(tab.id, { url });
     }
   };
 

--- a/utils/videoUtils.test.ts
+++ b/utils/videoUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { detectVideoService, isVideoUrl, getVideoThumbnail, VideoInfo } from "./videoUtils";
+import { detectVideoService, isVideoUrl, getVideoThumbnail, type VideoInfo } from "./videoUtils";
 
 describe("detectVideoService", () => {
   describe("YouTube", () => {

--- a/utils/videoUtils.ts
+++ b/utils/videoUtils.ts
@@ -8,42 +8,39 @@ export function detectVideoService(url: string): VideoInfo {
   // YouTube patterns
   const youtubeRegex =
     /^(?:https?:\/\/)?(?:www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=|shorts\/))([\w\-]{11})/;
-  const youtubeMatch = url.match(youtubeRegex);
+  const youtubeId = url.match(youtubeRegex)?.[1];
 
-  if (youtubeMatch) {
-    const videoId = youtubeMatch[1];
+  if (youtubeId) {
     return {
-      id: videoId,
+      id: youtubeId,
       service: "youtube",
       // Use YouTube's official Privacy Enhanced Mode domain
       // https://support.google.com/youtube/answer/171780
-      embedUrl: `https://www.youtube-nocookie.com/embed/${videoId}`,
+      embedUrl: `https://www.youtube-nocookie.com/embed/${youtubeId}`,
     };
   }
 
   // Vimeo patterns
   const vimeoRegex = /^(?:https?:\/\/)?(?:www\.)?(?:vimeo\.com\/)([0-9]+)/;
-  const vimeoMatch = url.match(vimeoRegex);
+  const vimeoId = url.match(vimeoRegex)?.[1];
 
-  if (vimeoMatch) {
-    const videoId = vimeoMatch[1];
+  if (vimeoId) {
     return {
-      id: videoId,
+      id: vimeoId,
       service: "vimeo",
-      embedUrl: `https://player.vimeo.com/video/${videoId}`,
+      embedUrl: `https://player.vimeo.com/video/${vimeoId}`,
     };
   }
 
   // TikTok patterns
   const tiktokRegex = /^(?:https?:\/\/)?(?:www\.)?tiktok\.com\/@[\w\-\.]+\/video\/([0-9]+)/;
-  const tiktokMatch = url.match(tiktokRegex);
+  const tiktokId = url.match(tiktokRegex)?.[1];
 
-  if (tiktokMatch) {
-    const videoId = tiktokMatch[1];
+  if (tiktokId) {
     return {
-      id: videoId,
+      id: tiktokId,
       service: "tiktok",
-      embedUrl: `https://www.tiktok.com/embed/v2/${videoId}`,
+      embedUrl: `https://www.tiktok.com/embed/v2/${tiktokId}`,
     };
   }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,4 @@
-/// <reference types="vitest" />
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({


### PR DESCRIPTION
## Changes

- Make `tsc --noEmit` pass: 19 type errors resolved across four source files.
- Put `pnpm compile` back into the CI check job.

No dependencies were added and `pnpm-lock.yaml` is untouched. No `any`, no `as`, no non-null assertions.

## `chrome.*` to `browser.*` (11 errors)

`Cannot find name 'chrome'` could not be fixed by configuration. `tsconfig.json` already extends `./.wxt/tsconfig.json`, and `.wxt/` is generated correctly by `wxt prepare` in `postinstall`. The cause is that nothing in the installed tree declares a global `chrome`: WXT 0.21.4 sources its types from `@wxt-dev/browser`, which is generated from `@types/chrome` but renames the namespace to `Browser` and therefore contains no `declare var chrome`. `@types/chrome` itself is not installed.

Using `browser.*` — which WXT does provide — has the same runtime behavior. `@wxt-dev/browser` is a one-liner:

```ts
export const browser = globalThis.browser?.runtime?.id ? globalThis.browser : globalThis.chrome;
```

On Chrome, `globalThis.browser` is undefined, so it falls through to `chrome`. The built `chrome-mv3/background.js` confirms it: every call goes through a binding defined as exactly that expression.

It also makes the file internally consistent. `entrypoints/background.ts` already used `browser.runtime.id` on line 2 and `browser.sidePanel` on line 38; only the lines in between used `chrome.`.

`build:firefox` was checked before and after and succeeds in both. `readingList` and `sidePanel` do not exist on Firefox anyway, and `browser.sidePanel` was already being called there before this change.

## The remaining eight

- **TS7006 ×2** in `App.tsx` were fallout from the above: `chrome.readingList.query({})` resolved to an error type, so `.sort((a, b) => …)` had nothing to infer from. They disappeared once `chrome` resolved.
- **TS2322 ×3** in `videoUtils.ts` come from `noUncheckedIndexedAccess`. `url.match(re)` returns `string | undefined` for a capture group, and the code assigned it to a `string` field. Rewritten as `url.match(re)?.[1]` with the existing truthiness check, so the undefined case is handled rather than suppressed.
- **TS1484 ×1** in `videoUtils.test.ts`: `VideoInfo` is a type and needs `import { type VideoInfo }` under `verbatimModuleSyntax`.
- **TS2769 ×1** in `vitest.config.ts`: importing `defineConfig` from `vite` and widening it with `/// <reference types="vitest" />` stopped working in Vitest 3 and does nothing in Vitest 4. `vitest/config` exports the `defineConfig` that knows about `test`. `vitest` is already a devDependency.

## Verification

`pnpm compile`, `pnpm test` (2 files, 39 tests) and `pnpm build` all pass. The test count is unchanged from before.

## Alternative not taken

Adding `@types/chrome` as a devDependency would also work and is arguably the more conventional fix, but it requires updating `pnpm-lock.yaml`. Worth reconsidering if `chrome.*` is preferred over `browser.*` in this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
